### PR TITLE
Style wallet button to match classic Facebook theme

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -13,6 +13,82 @@ code {
   font-size: 10px;
 }
 
+/* Wallet Adapter - Classic Facebook Theme */
 .wallet-adapter-button {
   font-family: 'Lucida Grande', Tahoma, Verdana, Arial, sans-serif !important;
+  background-color: #5972a8 !important;
+  background-image: linear-gradient(to bottom, #6d84b4, #5972a8) !important;
+  border: 1px solid #29447e !important;
+  border-radius: 3px !important;
+  color: white !important;
+  font-size: 11px !important;
+  font-weight: bold !important;
+  padding: 3px 8px !important;
+  height: auto !important;
+  line-height: 1.4 !important;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.2) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}
+
+.wallet-adapter-button:hover {
+  background-image: linear-gradient(to bottom, #5972a8, #4a5f8c) !important;
+  border-color: #1a356e !important;
+}
+
+.wallet-adapter-button:active {
+  background-image: linear-gradient(to bottom, #4a5f8c, #3b5998) !important;
+}
+
+.wallet-adapter-button-trigger {
+  background-color: #5972a8 !important;
+  background-image: linear-gradient(to bottom, #6d84b4, #5972a8) !important;
+}
+
+.wallet-adapter-dropdown {
+  font-family: 'Lucida Grande', Tahoma, Verdana, Arial, sans-serif !important;
+}
+
+.wallet-adapter-dropdown-list {
+  background-color: white !important;
+  border: 1px solid #9aafe5 !important;
+  border-radius: 3px !important;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1) !important;
+}
+
+.wallet-adapter-dropdown-list-item {
+  font-size: 11px !important;
+  padding: 8px 12px !important;
+  color: #3b5998 !important;
+}
+
+.wallet-adapter-dropdown-list-item:hover {
+  background-color: #d8dfea !important;
+}
+
+.wallet-adapter-modal-wrapper {
+  font-family: 'Lucida Grande', Tahoma, Verdana, Arial, sans-serif !important;
+}
+
+.wallet-adapter-modal-container {
+  background-color: white !important;
+  border: 1px solid #9aafe5 !important;
+  border-radius: 3px !important;
+}
+
+.wallet-adapter-modal-title {
+  color: #3b5998 !important;
+  font-weight: bold !important;
+}
+
+.wallet-adapter-modal-list .wallet-adapter-button {
+  background-color: #f5f5f5 !important;
+  background-image: none !important;
+  border: 1px solid #ccc !important;
+  color: #333 !important;
+  text-shadow: none !important;
+}
+
+.wallet-adapter-modal-list .wallet-adapter-button:hover {
+  background-color: #e8e8e8 !important;
+  border-color: #3b5998 !important;
 }


### PR DESCRIPTION
Adds comprehensive CSS overrides for the Solana wallet adapter to match the classic Facebook aesthetic:

- Gradient button backgrounds matching Facebook blue (#5972a8, #6d84b4)
- Proper borders and rounded corners (3px)
- Hover and active states
- Dropdown list styling with Facebook colors
- Modal styling for wallet selection

Matches the overall 2004-2008 Facebook UI vibe.