### PR TITLE
Improve wallet detection

### DIFF
--- a/app/src/components/WalletButton.tsx
+++ b/app/src/components/WalletButton.tsx
@@ -120,14 +120,20 @@ export function WalletButton() {
           
           {readyConnectors.length === 0 ? (
             <div style={{ padding: "12px", fontSize: "11px", color: "#666", textAlign: "center" }}>
-              No wallets detected.<br />
+              No wallets detected.<br /><br />
+              <span style={{ fontSize: "10px", color: "#999" }}>
+                {connectors.length > 0 
+                  ? `Found ${connectors.length} wallet(s) but none ready`
+                  : "No Wallet Standard wallets found"}
+              </span>
+              <br /><br />
               <a 
                 href="https://phantom.app" 
                 target="_blank" 
                 rel="noopener noreferrer"
                 style={{ color: "#3b5998", textDecoration: "underline" }}
               >
-                Install Phantom →
+                Install Phantom ↗
               </a>
             </div>
           ) : (

--- a/app/src/components/WalletProvider.tsx
+++ b/app/src/components/WalletProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useMemo } from "react";
 import { AppProvider } from "@solana/connector/react";
 import { getDefaultConfig } from "@solana/connector/headless";
 
@@ -9,9 +9,15 @@ interface Props {
 }
 
 export const WalletProvider: FC<Props> = ({ children }) => {
-  const config = getDefaultConfig({
-    appName: "Clawbook",
-  });
+  const config = useMemo(() => {
+    return getDefaultConfig({
+      appName: "Clawbook",
+      appUrl: typeof window !== "undefined" ? window.location.origin : "https://clawbook.vercel.app",
+      autoConnect: true,
+      enableMobile: true,
+      // Don't restrict wallets - show all available
+    });
+  }, []);
 
   return <AppProvider connectorConfig={config}>{children}</AppProvider>;
 };


### PR DESCRIPTION
ConnectorKit uses Wallet Standard - wallets must be installed as browser extensions.

Changes:
- Added `autoConnect: true`
- Added `enableMobile: true` for mobile wallet adapter
- Added `appUrl` for mobile wallet deep linking
- Better debug message showing found vs ready wallet count

Note: If no wallets show, user needs to install a Wallet Standard compatible extension like Phantom, Solflare, or Backpack.