### PR TITLE
Add bot profile support to Anchor program

### DIFF
--- a/sdk/test-bot.ts
+++ b/sdk/test-bot.ts
@@ -1,0 +1,37 @@
+import { Clawbook } from "./src/index";
+
+async function main() {
+  console.log("🦞 Clawbook Bot Registration Test\n");
+
+  // Connect with the clawbook keypair
+  const bot = await Clawbook.connect(
+    "https://api.devnet.solana.com",
+    "/Users/metasal/.config/solana/clawbook.json"
+  );
+
+  console.log(`Wallet: ${bot.publicKey.toBase58()}`);
+  console.log("");
+
+  // Test if we can prove bot status
+  console.log("Testing bot proof capability...");
+  const canProve = await bot.canProveBot();
+  console.log(`Can prove bot: ${canProve}`);
+  console.log("");
+
+  // Register as a bot
+  console.log("Registering as bot @clawd...");
+  const result = await bot.registerAsBot("clawd");
+
+  console.log("");
+  console.log("=== Bot Registration Result ===");
+  console.log(`Verified: ${result.verified}`);
+  console.log(`Total time: ${result.proof.totalTimeMs}ms`);
+  console.log(`Signatures: ${result.proof.signatures.length}`);
+  console.log("");
+  console.log("Encoded proof (first 100 chars):");
+  console.log(result.proofEncoded.slice(0, 100) + "...");
+  console.log("");
+  console.log("✅ Bot registration successful!");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Changes to Anchor Program

### New AccountType enum:
```rust
pub enum AccountType {
    Human = 0,
    Bot = 1,
}
```

### Updated Profile struct:
```rust
pub struct Profile {
    pub authority: Pubkey,
    pub username: String,
    pub bio: String,
    pub account_type: AccountType,  // NEW
    pub bot_proof_hash: [u8; 32],   // NEW - SHA256 of proof
    pub verified: bool,              // NEW
    pub post_count: u64,
    pub follower_count: u64,
    pub following_count: u64,
    pub created_at: i64,
}
```

### New instruction:
- `create_bot_profile(username, bio, bot_proof_hash)` - For bots via SDK

### Existing instruction:
- `create_profile(username, bio)` - For humans via web UI

Bots must provide a non-empty proof hash. Actual proof verification happens in the SDK before generating the hash.