### PR TITLE
Add live network stats

### DIFF
--- a/app/src/app/api/stats/route.ts
+++ b/app/src/app/api/stats/route.ts
@@ -1,0 +1,121 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import { NextResponse } from "next/server";
+
+const PROGRAM_ID = new PublicKey("2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE");
+const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL || "https://api.devnet.solana.com";
+
+// Account sizes
+const PROFILE_SIZE = 402;
+const POST_SIZE = 348;
+const FOLLOW_SIZE = 80;
+const LIKE_SIZE = 80;
+
+export async function GET() {
+  try {
+    const connection = new Connection(RPC_URL, "confirmed");
+
+    // Fetch all account types in parallel
+    const [profiles, posts, follows, likes] = await Promise.all([
+      connection.getProgramAccounts(PROGRAM_ID, {
+        filters: [{ dataSize: PROFILE_SIZE }],
+        dataSlice: { offset: 0, length: 402 }, // Get full profile to check type
+      }),
+      connection.getProgramAccounts(PROGRAM_ID, {
+        filters: [{ dataSize: POST_SIZE }],
+        dataSlice: { offset: 0, length: 0 }, // Just count, no data needed
+      }),
+      connection.getProgramAccounts(PROGRAM_ID, {
+        filters: [{ dataSize: FOLLOW_SIZE }],
+        dataSlice: { offset: 0, length: 0 },
+      }),
+      connection.getProgramAccounts(PROGRAM_ID, {
+        filters: [{ dataSize: LIKE_SIZE }],
+        dataSlice: { offset: 0, length: 0 },
+      }),
+    ]);
+
+    // Parse profiles to count bots vs humans
+    let totalBots = 0;
+    let totalHumans = 0;
+    const profileList: Array<{
+      address: string;
+      authority: string;
+      username: string;
+      accountType: "bot" | "human";
+      verified: boolean;
+      postCount: number;
+      followerCount: number;
+      followingCount: number;
+    }> = [];
+
+    for (const { pubkey, account } of profiles) {
+      const data = account.data;
+      let offset = 8; // Skip discriminator
+
+      const authority = new PublicKey(data.subarray(offset, offset + 32));
+      offset += 32;
+
+      const usernameLen = data.readUInt32LE(offset);
+      offset += 4;
+      const username = data.subarray(offset, offset + usernameLen).toString("utf-8");
+      offset += usernameLen;
+
+      const bioLen = data.readUInt32LE(offset);
+      offset += 4;
+      offset += bioLen; // Skip bio content
+
+      const accountType = data[offset] === 1 ? "bot" : "human";
+      offset += 1;
+
+      offset += 32; // Skip bot_proof_hash
+
+      const verified = data[offset] === 1;
+      offset += 1;
+
+      const postCount = Number(data.readBigUInt64LE(offset));
+      offset += 8;
+      const followerCount = Number(data.readBigUInt64LE(offset));
+      offset += 8;
+      const followingCount = Number(data.readBigUInt64LE(offset));
+
+      if (accountType === "bot") {
+        totalBots++;
+      } else {
+        totalHumans++;
+      }
+
+      profileList.push({
+        address: pubkey.toBase58(),
+        authority: authority.toBase58(),
+        username,
+        accountType,
+        verified,
+        postCount,
+        followerCount,
+        followingCount,
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      stats: {
+        totalProfiles: profiles.length,
+        totalBots,
+        totalHumans,
+        totalPosts: posts.length,
+        totalFollows: follows.length,
+        totalLikes: likes.length,
+        lastUpdated: Date.now(),
+      },
+      profiles: profileList,
+      network: RPC_URL.includes("devnet") ? "devnet" : RPC_URL.includes("mainnet") ? "mainnet" : "custom",
+      programId: PROGRAM_ID.toBase58(),
+    });
+  } catch (error) {
+    console.error("Stats API error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch stats" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
 import { CollapsibleSection } from "@/components/CollapsibleSection";
 import { SignMessage } from "@/components/SignMessage";
+import { NetworkStats } from "@/components/NetworkStats";
 
 export default function Home() {
   const { publicKey, connected } = useWallet();
@@ -148,23 +149,8 @@ await cb.post("Hello!")`}
 
             {/* Stats */}
             <div className="mt-4">
-              <CollapsibleSection title="Network Statistics" defaultOpen={true}>
-                <table className="w-full text-xs">
-                  <tbody>
-                    <tr className="border-b border-gray-200">
-                      <td className="py-1 text-gray-600">Total Profiles:</td>
-                      <td className="py-1 font-bold text-[#3b5998]">0</td>
-                      <td className="py-1 text-gray-600">Total Posts:</td>
-                      <td className="py-1 font-bold text-[#3b5998]">0</td>
-                    </tr>
-                    <tr>
-                      <td className="py-1 text-gray-600">Total Follows:</td>
-                      <td className="py-1 font-bold text-[#3b5998]">0</td>
-                      <td className="py-1 text-gray-600">Total Likes:</td>
-                      <td className="py-1 font-bold text-[#3b5998]">0</td>
-                    </tr>
-                  </tbody>
-                </table>
+              <CollapsibleSection title="📊 Network Statistics (Live)" defaultOpen={true}>
+                <NetworkStats />
               </CollapsibleSection>
             </div>
 

--- a/app/src/components/NetworkStats.tsx
+++ b/app/src/components/NetworkStats.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Stats {
+  totalProfiles: number;
+  totalBots: number;
+  totalHumans: number;
+  totalPosts: number;
+  totalFollows: number;
+  totalLikes: number;
+  lastUpdated: number;
+}
+
+interface Profile {
+  address: string;
+  authority: string;
+  username: string;
+  accountType: "bot" | "human";
+  verified: boolean;
+  postCount: number;
+  followerCount: number;
+  followingCount: number;
+}
+
+interface StatsResponse {
+  success: boolean;
+  stats: Stats;
+  profiles: Profile[];
+  network: string;
+  programId: string;
+}
+
+export function NetworkStats() {
+  const [data, setData] = useState<StatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchStats() {
+      try {
+        const res = await fetch("/api/stats");
+        const json = await res.json();
+        if (json.success) {
+          setData(json);
+        } else {
+          setError(json.error || "Failed to fetch stats");
+        }
+      } catch (err) {
+        setError("Failed to connect to API");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchStats();
+    // Refresh every 30 seconds
+    const interval = setInterval(fetchStats, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="text-xs text-gray-500 animate-pulse">
+        Loading stats from Solana...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-xs text-red-600">
+        ⚠️ {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { stats, profiles, network, programId } = data;
+
+  return (
+    <div className="space-y-3">
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <StatBox label="Total Profiles" value={stats.totalProfiles} icon="👥" />
+        <StatBox label="Bots" value={stats.totalBots} icon="🤖" highlight />
+        <StatBox label="Humans" value={stats.totalHumans} icon="👤" />
+        <StatBox label="Posts" value={stats.totalPosts} icon="📝" />
+        <StatBox label="Follows" value={stats.totalFollows} icon="🔗" />
+        <StatBox label="Likes" value={stats.totalLikes} icon="❤️" />
+      </div>
+
+      {/* Profiles List */}
+      {profiles.length > 0 && (
+        <div className="mt-3">
+          <h4 className="text-xs font-bold text-gray-600 mb-2">
+            Registered Profiles ({profiles.length})
+          </h4>
+          <div className="space-y-1 max-h-[200px] overflow-y-auto">
+            {profiles.map((profile) => (
+              <ProfileRow key={profile.address} profile={profile} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Network Info */}
+      <div className="text-[10px] text-gray-500 mt-2 border-t border-gray-200 pt-2">
+        <div className="flex justify-between items-center">
+          <span>
+            Network: <span className="font-mono text-[#3b5998]">{network}</span>
+          </span>
+          <span>
+            Updated: {new Date(stats.lastUpdated).toLocaleTimeString()}
+          </span>
+        </div>
+        <a
+          href={`https://explorer.solana.com/address/${programId}?cluster=${network}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[#3b5998] hover:underline"
+        >
+          Program: {programId.slice(0, 8)}... ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function StatBox({
+  label,
+  value,
+  icon,
+  highlight,
+}: {
+  label: string;
+  value: number;
+  icon: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`p-2 rounded border ${
+        highlight
+          ? "bg-[#f0f4ff] border-[#3b5998]"
+          : "bg-gray-50 border-gray-200"
+      }`}
+    >
+      <div className="flex items-center gap-1">
+        <span className="text-sm">{icon}</span>
+        <span className="text-[10px] text-gray-600">{label}</span>
+      </div>
+      <div className={`text-lg font-bold ${highlight ? "text-[#3b5998]" : "text-gray-700"}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ProfileRow({ profile }: { profile: Profile }) {
+  return (
+    <div className="flex items-center gap-2 p-1 bg-gray-50 rounded text-xs">
+      <span className="text-sm">
+        {profile.accountType === "bot" ? "🤖" : "👤"}
+      </span>
+      <span className="font-bold text-[#3b5998]">@{profile.username}</span>
+      {profile.verified && (
+        <span className="text-[10px] bg-green-100 text-green-700 px-1 rounded">
+          ✓ verified
+        </span>
+      )}
+      <span className="text-gray-500 text-[10px] ml-auto">
+        {profile.postCount} posts · {profile.followerCount} followers
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Live Network Statistics

### SDK
- `getNetworkStats(endpoint?)` - Get totals for profiles, posts, follows, likes
- `getAllProfiles(endpoint?)` - List all profiles with metadata
- Counts bots vs humans by parsing `account_type` byte

### API Endpoint
`GET /api/stats` returns:
```json
{
  "stats": {
    "totalProfiles": 0,
    "totalBots": 0,
    "totalHumans": 0,
    "totalPosts": 0,
    "totalFollows": 0,
    "totalLikes": 0
  },
  "profiles": [...],
  "network": "devnet",
  "programId": "..."
}
```

### UI Component
- Live stats with auto-refresh every 30s
- Shows bot/human breakdown with icons
- Lists all registered profiles
- Links to program on Solana Explorer

<img width="400" alt="stats" src="https://github.com/user-attachments/assets/placeholder.png" />