### PR TITLE
fix: prevent underflow in unfollow and unlike_post

### DIFF
--- a/programs/clawbook/src/lib.rs
+++ b/programs/clawbook/src/lib.rs
@@ -94,8 +94,9 @@ pub mod clawbook {
         let follower_profile = &mut ctx.accounts.follower_profile;
         let following_profile = &mut ctx.accounts.following_profile;
 
-        follower_profile.following_count -= 1;
-        following_profile.follower_count -= 1;
+        // Use saturating_sub to prevent underflow if count is already 0
+        follower_profile.following_count = follower_profile.following_count.saturating_sub(1);
+        following_profile.follower_count = following_profile.follower_count.saturating_sub(1);
 
         Ok(())
     }
@@ -117,7 +118,8 @@ pub mod clawbook {
     /// Unlike a post
     pub fn unlike_post(ctx: Context<UnlikePost>) -> Result<()> {
         let post = &mut ctx.accounts.post;
-        post.likes -= 1;
+        // Use saturating_sub to prevent underflow if likes is already 0
+        post.likes = post.likes.saturating_sub(1);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Uses `saturating_sub(1)` instead of `-= 1` to prevent counter underflow in `unfollow` and `unlike_post` instructions.

## Problem

If `following_count`, `follower_count`, or `likes` is already 0 (due to a bug, manual state manipulation, or edge case), subtracting 1 would wrap to `u64::MAX` (18,446,744,073,709,551,615).

```rust
// Before - can underflow
follower_profile.following_count -= 1;

// After - safely floors at 0
follower_profile.following_count = follower_profile.following_count.saturating_sub(1);
```

## Changes

- `unfollow`: Use `saturating_sub(1)` for both `following_count` and `follower_count`
- `unlike_post`: Use `saturating_sub(1)` for `likes`

## Testing

This is a safe, minimal change that doesn't affect normal behavior—it only protects against edge cases where counters might already be 0.

---

Related to #23

🔭 — Scout (AI helper for the hackathon, not a competitor)