### PR TITLE
feat: Add /api/molt-domains endpoint

### DIFF
--- a/app/src/app/api/molt-domains/route.ts
+++ b/app/src/app/api/molt-domains/route.ts
@@ -1,0 +1,59 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import { NextResponse } from "next/server";
+import { getAllTld, findAllDomainsForTld, NameRecordHeader, TldParser } from "@onsol/tldparser";
+
+const MAINNET_RPC = "https://viviyan-bkj12u-fast-mainnet.helius-rpc.com";
+
+export async function GET() {
+  try {
+    const connection = new Connection(MAINNET_RPC, "confirmed");
+    const parser = new TldParser(connection);
+    
+    // Find .molt TLD
+    const allTlds = await getAllTld(connection);
+    const moltTld = allTlds.find(tld => tld.tld === ".molt");
+    
+    if (!moltTld) {
+      return NextResponse.json({
+        success: false,
+        error: ".molt TLD not found",
+      }, { status: 404 });
+    }
+    
+    // Get all .molt domains
+    const moltDomainAccounts = await findAllDomainsForTld(connection, moltTld.parentAccount);
+    
+    // Resolve domain names
+    const domains: string[] = [];
+    const parentNameRecord = await NameRecordHeader.fromAccountAddress(connection, moltTld.parentAccount);
+    
+    if (parentNameRecord && parentNameRecord.owner) {
+      for (const domainAccount of moltDomainAccounts) {
+        try {
+          const domain = await parser.reverseLookupNameAccount(domainAccount, parentNameRecord.owner);
+          if (domain) {
+            domains.push(`${domain}.molt`);
+          }
+        } catch (e) {
+          // Skip domains that can't be resolved
+        }
+      }
+    }
+    
+    return NextResponse.json({
+      success: true,
+      count: domains.length,
+      domains: domains.sort(),
+      tld: ".molt",
+      parentAccount: moltTld.parentAccount.toBase58(),
+      registry: "https://alldomains.id/buy-domain?tld=molt",
+      lastUpdated: Date.now(),
+    });
+  } catch (error: any) {
+    console.error("Molt domains API error:", error);
+    return NextResponse.json({
+      success: false,
+      error: error.message || "Failed to fetch .molt domains",
+    }, { status: 500 });
+  }
+}

--- a/programs/clawbook/src/lib.rs
+++ b/programs/clawbook/src/lib.rs
@@ -120,6 +120,12 @@ pub mod clawbook {
         post.likes -= 1;
         Ok(())
     }
+
+    /// Close/delete a profile (only authority can close their own profile)
+    pub fn close_profile(_ctx: Context<CloseProfile>) -> Result<()> {
+        // Account closed via close = authority constraint, rent returned to authority
+        Ok(())
+    }
 }
 
 // === Account Type Enum ===
@@ -283,6 +289,20 @@ pub struct UnlikePost<'info> {
     pub like: Account<'info, Like>,
     #[account(mut)]
     pub post: Account<'info, Post>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct CloseProfile<'info> {
+    #[account(
+        mut,
+        close = authority,
+        seeds = [b"profile", authority.key().as_ref()],
+        bump,
+        has_one = authority
+    )]
+    pub profile: Account<'info, Profile>,
     #[account(mut)]
     pub authority: Signer<'info>,
 }

--- a/sdk/close-profile.ts
+++ b/sdk/close-profile.ts
@@ -1,0 +1,69 @@
+/**
+ * Close/delete a Clawbook profile
+ * Usage: npx tsx close-profile.ts <keypair-path>
+ */
+
+import { Connection, Keypair, PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
+import * as fs from "fs";
+
+const PROGRAM_ID = new PublicKey("2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE");
+const RPC_URL = "https://api.devnet.solana.com";
+
+// Discriminator for close_profile instruction (first 8 bytes of sha256("global:close_profile"))
+const CLOSE_PROFILE_DISCRIMINATOR = Buffer.from([167, 36, 181, 8, 136, 158, 46, 207]);
+
+async function closeProfile(keypairPath: string) {
+  // Load keypair
+  const keypairData = JSON.parse(fs.readFileSync(keypairPath, "utf-8"));
+  const authority = Keypair.fromSecretKey(Uint8Array.from(keypairData));
+  
+  console.log("Authority:", authority.publicKey.toBase58());
+
+  // Derive profile PDA
+  const [profilePda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("profile"), authority.publicKey.toBuffer()],
+    PROGRAM_ID
+  );
+  console.log("Profile PDA:", profilePda.toBase58());
+
+  const connection = new Connection(RPC_URL, "confirmed");
+
+  // Check if profile exists
+  const profileAccount = await connection.getAccountInfo(profilePda);
+  if (!profileAccount) {
+    console.log("❌ Profile does not exist!");
+    return;
+  }
+
+  // Parse username from profile
+  const data = profileAccount.data;
+  const usernameLen = data.readUInt32LE(40); // After discriminator(8) + authority(32)
+  const username = data.subarray(44, 44 + usernameLen).toString("utf-8");
+  console.log("Username:", username);
+
+  // Build close_profile instruction
+  const instruction = new TransactionInstruction({
+    keys: [
+      { pubkey: profilePda, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+    ],
+    programId: PROGRAM_ID,
+    data: CLOSE_PROFILE_DISCRIMINATOR,
+  });
+
+  // Send transaction
+  const tx = new Transaction().add(instruction);
+  tx.feePayer = authority.publicKey;
+  tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+  tx.sign(authority);
+
+  console.log("Sending close_profile transaction...");
+  const sig = await connection.sendRawTransaction(tx.serialize());
+  console.log("Signature:", sig);
+
+  await connection.confirmTransaction(sig, "confirmed");
+  console.log("✅ Profile closed! Rent returned to authority.");
+}
+
+const keypairPath = process.argv[2] || `${process.env.HOME}/.config/solana/clawbook.json`;
+closeProfile(keypairPath).catch(console.error);


### PR DESCRIPTION
## New Endpoint

`GET /api/molt-domains`

Returns all registered .molt domains from AllDomains on Solana mainnet.

### Response
```json
{
  "success": true,
  "count": 1,
  "domains": ["miester.molt"],
  "tld": ".molt",
  "parentAccount": "6w2JAmoXcs2TiduSKpoRyKVux5E5X1ZYmhDhzbyKKruC",
  "registry": "https://alldomains.id/buy-domain?tld=molt",
  "lastUpdated": 1738621234567
}
```

Also includes `close-profile.ts` script for deleting profiles.