### PR TITLE
fix: requestHeapFrame to fix OOM on follow/like/post

### DIFF
--- a/app/src/app/profile/[address]/page.tsx
+++ b/app/src/app/profile/[address]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
-import { PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
+import { ComputeBudgetProgram, PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { PostFeed } from "@/components/PostFeed";
@@ -187,7 +187,10 @@ export default function ViewProfile() {
         data: getFollowDisc(),
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(
+        ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }),
+        ix
+      );
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);
@@ -237,7 +240,10 @@ export default function ViewProfile() {
         data: getUnfollowDisc(),
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(
+        ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }),
+        ix
+      );
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
-import { PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
+import { ComputeBudgetProgram, PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { CollapsibleSection } from "@/components/CollapsibleSection";
@@ -188,7 +188,7 @@ export default function ProfilePage() {
         data: ixData,
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), ix);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);
@@ -250,7 +250,7 @@ export default function ProfilePage() {
         data: ixData,
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), ix);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);
@@ -312,7 +312,7 @@ export default function ProfilePage() {
         data: ixData,
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), ix);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);
@@ -349,7 +349,7 @@ export default function ProfilePage() {
         data: getCloseProfileDisc(),
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), ix);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);

--- a/app/src/components/PostFeed.tsx
+++ b/app/src/components/PostFeed.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
-import { PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
+import { ComputeBudgetProgram, PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
 import Link from "next/link";
 
 const PROGRAM_ID = new PublicKey("2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE");
@@ -77,7 +77,7 @@ export function PostFeed({ author }: { author?: string }) {
         data: getLikePostDisc(),
       });
 
-      const tx = new Transaction().add(ix);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), ix);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       const signed = await signTransaction(tx);

--- a/app/src/components/RegisterProfile.tsx
+++ b/app/src/components/RegisterProfile.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useWallet, useConnection } from "@solana/wallet-adapter-react";
-import { PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
+import { ComputeBudgetProgram, PublicKey, Transaction, TransactionInstruction } from "@solana/web3.js";
 
 const PROGRAM_ID = new PublicKey("2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE");
 
@@ -135,7 +135,7 @@ export function RegisterProfile() {
         data,
       });
       
-      const tx = new Transaction().add(instruction);
+      const tx = new Transaction().add(ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 }), instruction);
       tx.feePayer = publicKey;
       tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
       


### PR DESCRIPTION
## Problem
When a user tries to follow someone on Clawbook, the transaction fails with:
```
memory allocation failed, out of memory
Program 2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE failed: SBF program panicked
```

The program only consumed 3,692 of 199,700 compute units — it's not a CU issue. The Light Protocol SDK imports inflate the program binary's heap footprint beyond the default 32KB Solana heap limit.

## Fix
Added `ComputeBudgetProgram.requestHeapFrame({ bytes: 262144 })` (256KB) to every transaction that calls the Clawbook program:
- **Follow / Unfollow** — profile/[address]/page.tsx
- **Create Profile / Update / Post / Delete** — profile/page.tsx  
- **Like** — PostFeed.tsx
- **Register** — RegisterProfile.tsx

This tells the Solana runtime to allocate 256KB heap instead of 32KB, which is well within limits and costs no extra fees.