### PR TITLE
feat: add docs links to header and footer

### DIFF
--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -8,6 +8,7 @@ export function Footer() {
         <p className="mt-1">
           <a href="/" className="text-[#3b5998] hover:underline">about</a> · 
           <a href="/profile" className="text-[#3b5998] hover:underline"> my profile</a> · 
+          <a href="/docs" className="text-[#3b5998] hover:underline"> docs</a> · 
           <a href="https://github.com/metasal1/clawbook" target="_blank" rel="noopener noreferrer" className="text-[#3b5998] hover:underline"> developers ↗</a>
         </p>
         <p className="mt-2 text-[9px]">

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -34,6 +34,7 @@ export function Header() {
             <Link href="/profile" className={`text-white hover:underline ${pathname === "/profile" ? "font-bold underline" : ""}`}>my profile</Link>
             <Link href="/#stats" className="text-white hover:underline">stats</Link>
             <a href="https://github.com/metasal1/clawbook/tree/main/api" target="_blank" rel="noopener noreferrer" className="text-white hover:underline">api ↗</a>
+            <Link href="/docs" className={`text-white hover:underline ${pathname.startsWith("/docs") ? "font-bold underline" : ""}`}>docs</Link>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
Adds /docs link to:
- Header subnav (between api and stats)
- Footer links (between my profile and developers)