### PR TITLE
feat: ZK compressed posts — rent-free posting via Light Protocol

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "clawbook-app",
       "version": "0.1.0",
       "dependencies": {
+        "@lightprotocol/stateless.js": "^0.22.0",
         "@onsol/tldparser": "^1.2.1",
         "@solana/connector": "^0.2.4",
         "@solana/wallet-adapter-base": "^0.9.27",
@@ -1305,6 +1306,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@coral-xyz/borsh": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.68.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
@@ -2459,6 +2476,74 @@
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.14.0.tgz",
       "integrity": "sha512-kJFu1+asWQmU9XlfR1RM3lYR76wuEoPyZvkI/CNjpft78BQr3+MMf3Nu77ABzcKFnhIcmAkOLlDQ6B8L6hDXHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@lightprotocol/stateless.js": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@lightprotocol/stateless.js/-/stateless.js-0.22.0.tgz",
+      "integrity": "sha512-2I7g/pIq/Bbm6Qax1djT4TEwBHmGWJpvhF2pdRyyO6k3f4a1ZR3hDdesbpZ99FPH7LysiCcMR1cJvVjw39ZNfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@coral-xyz/borsh": "^0.29.0",
+        "@noble/hashes": "1.5.0",
+        "bn.js": "^5.2.1",
+        "bs58": "^6.0.0",
+        "buffer": "6.0.3",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^8.0.0",
+        "camelcase-keys": "^9.1.3",
+        "superstruct": "2.0.2"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": ">=1.73.5"
+      }
+    },
+    "node_modules/@lightprotocol/stateless.js/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@lightprotocol/stateless.js/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@lightprotocol/stateless.js/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
@@ -14939,6 +15024,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/buffer-layout": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -15023,6 +15117,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-9.1.3.tgz",
+      "integrity": "sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^8.0.0",
+        "map-obj": "5.0.0",
+        "quick-lru": "^6.1.1",
+        "type-fest": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -18207,6 +18343,18 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.0.tgz",
+      "integrity": "sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -20766,6 +20914,18 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/radix3": {
       "version": "1.1.2",

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@lightprotocol/stateless.js": "^0.22.0",
     "@onsol/tldparser": "^1.2.1",
     "@solana/connector": "^0.2.4",
     "@solana/wallet-adapter-base": "^0.9.27",

--- a/app/src/app/api/compressed-post/route.ts
+++ b/app/src/app/api/compressed-post/route.ts
@@ -1,0 +1,260 @@
+/**
+ * API route for ZK Compressed Post proof fetching.
+ *
+ * The Light Protocol SDK has Node.js dependencies that don't work client-side,
+ * so we fetch the validity proof and derive addresses server-side.
+ *
+ * POST /api/compressed-post
+ * Body: { wallet: string, content: string }
+ * Returns: proof data, tree info, remaining accounts for building the tx client-side
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { PublicKey, Connection } from "@solana/web3.js";
+import {
+  createRpc,
+  defaultTestStateTreeAccounts,
+  defaultStaticAccountsStruct,
+  deriveAddressSeed,
+  deriveAddress,
+  getRegisteredProgramPda,
+  getAccountCompressionAuthority,
+  lightSystemProgram,
+  accountCompressionProgram,
+  noopProgram,
+  bn,
+} from "@lightprotocol/stateless.js";
+
+const PROGRAM_ID = new PublicKey(
+  "2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE"
+);
+
+/**
+ * Build a compression-capable RPC URL.
+ * Prefers HELIUS_API_KEY env, then falls back to NEXT_PUBLIC_RPC_URL.
+ */
+function getCompressionRpcUrl(): string {
+  if (process.env.HELIUS_API_KEY) {
+    return `https://devnet.helius-rpc.com?api-key=${process.env.HELIUS_API_KEY}`;
+  }
+  if (process.env.NEXT_PUBLIC_RPC_URL) {
+    return process.env.NEXT_PUBLIC_RPC_URL;
+  }
+  // Fallback to standard devnet (will fail for compression calls)
+  return "https://api.devnet.solana.com";
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { wallet, content } = body;
+
+    if (!wallet || !content) {
+      return NextResponse.json(
+        { error: "Missing wallet or content" },
+        { status: 400 }
+      );
+    }
+
+    if (content.length > 280) {
+      return NextResponse.json(
+        { error: "Content must be 280 characters or less" },
+        { status: 400 }
+      );
+    }
+
+    const walletPubkey = new PublicKey(wallet);
+    const rpcUrl = getCompressionRpcUrl();
+
+    // Create compression-aware RPC (same URL for both standard and compression endpoints)
+    const rpc = createRpc(rpcUrl, rpcUrl);
+
+    // Derive profile PDA to read post_count
+    const [profilePda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("profile"), walletPubkey.toBuffer()],
+      PROGRAM_ID
+    );
+
+    // Read profile account to get current post_count
+    const profileAccount = await rpc.getAccountInfo(profilePda);
+    if (!profileAccount) {
+      return NextResponse.json(
+        { error: "Profile not found. Create a profile first." },
+        { status: 404 }
+      );
+    }
+
+    // Parse post_count from profile data
+    // Profile layout: 8 (disc) + 32 (authority) + 4+var (username) + 4+var (bio) + 4+var (pfp) + 1 (account_type) + 32 (bot_proof_hash) + 1 (verified) + 8 (post_count) + ...
+    const data = profileAccount.data;
+    let offset = 8 + 32; // skip discriminator + authority
+
+    // username (borsh string: 4 byte len + data)
+    const usernameLen = data.readUInt32LE(offset);
+    offset += 4 + usernameLen;
+
+    // bio
+    const bioLen = data.readUInt32LE(offset);
+    offset += 4 + bioLen;
+
+    // pfp
+    const pfpLen = data.readUInt32LE(offset);
+    offset += 4 + pfpLen;
+
+    // account_type (1 byte) + bot_proof_hash (32 bytes) + verified (1 byte)
+    offset += 1 + 32 + 1;
+
+    // post_count (u64 LE)
+    const postCountBuf = data.subarray(offset, offset + 8);
+    const postCount = Number(postCountBuf.readBigUInt64LE(0));
+
+    // Get default devnet tree accounts
+    const treeAccounts = defaultTestStateTreeAccounts();
+    const staticAccounts = defaultStaticAccountsStruct();
+
+    // Derive address seed for the compressed post
+    // Must match on-chain: seeds = [b"compressed_post", fee_payer, post_count_bytes]
+    const postCountBytes = Buffer.alloc(8);
+    postCountBytes.writeBigUInt64LE(BigInt(postCount));
+
+    const addressSeed = deriveAddressSeed(
+      [
+        Buffer.from("compressed_post"),
+        walletPubkey.toBuffer(),
+        postCountBytes,
+      ],
+      PROGRAM_ID
+    );
+
+    const address = deriveAddress(addressSeed, treeAccounts.addressTree);
+
+    // Convert PublicKey to BN254 for the proof request
+    const addressBn = bn(address.toBytes());
+
+    // Get validity proof for the new address
+    const validityProof = await rpc.getValidityProofV0(
+      [], // no input hashes (creating new account)
+      [
+        {
+          address: addressBn,
+          tree: treeAccounts.addressTree,
+          queue: treeAccounts.addressQueue,
+        },
+      ]
+    );
+
+    // Tree accounts layout in remaining_accounts[8..]:
+    // [0] = state tree (merkleTree)
+    // [1] = nullifier queue
+    // [2] = address tree
+    // [3] = address queue
+    const outputTreeIndex = 0;
+    const addressMerkleTreePubkeyIndex = 2;
+    const addressQueuePubkeyIndex = 3;
+
+    // Root index for the address tree from the validity proof
+    const addressRootIndex = validityProof.rootIndices[0];
+
+    // The Light System Program ID
+    const lightSystemProgramId = new PublicKey(lightSystemProgram);
+    const accountCompressionProgramId = new PublicKey(
+      accountCompressionProgram
+    );
+    const noopProgramId = new PublicKey(noopProgram);
+
+    // Build remaining accounts for CpiAccounts v1 (default config, no optional accounts)
+    // Order matches CompressionCpiAccountIndex enum (skipping optional sol_pool_pda, decompression_recipient, cpi_context)
+    const remainingAccounts = [
+      {
+        pubkey: lightSystemProgramId.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: walletPubkey.toBase58(),
+        isWritable: true,
+        isSigner: true,
+      }, // authority = fee_payer
+      {
+        pubkey: staticAccounts.registeredProgramPda.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: noopProgramId.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: staticAccounts.accountCompressionAuthority.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: accountCompressionProgramId.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      },
+      {
+        pubkey: PROGRAM_ID.toBase58(),
+        isWritable: false,
+        isSigner: false,
+      }, // invoking program
+      {
+        pubkey: "11111111111111111111111111111111",
+        isWritable: false,
+        isSigner: false,
+      }, // system program
+      // Tree accounts:
+      {
+        pubkey: treeAccounts.merkleTree.toBase58(),
+        isWritable: true,
+        isSigner: false,
+      }, // state tree [0]
+      {
+        pubkey: treeAccounts.nullifierQueue.toBase58(),
+        isWritable: true,
+        isSigner: false,
+      }, // nullifier queue [1]
+      {
+        pubkey: treeAccounts.addressTree.toBase58(),
+        isWritable: true,
+        isSigner: false,
+      }, // address tree [2]
+      {
+        pubkey: treeAccounts.addressQueue.toBase58(),
+        isWritable: true,
+        isSigner: false,
+      }, // address queue [3]
+    ];
+
+    if (!validityProof.compressedProof) {
+      return NextResponse.json(
+        { error: "Failed to get compressed proof from indexer" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      proof: {
+        a: Array.from(validityProof.compressedProof.a),
+        b: Array.from(validityProof.compressedProof.b),
+        c: Array.from(validityProof.compressedProof.c),
+      },
+      addressTreeInfo: {
+        addressMerkleTreePubkeyIndex,
+        addressQueuePubkeyIndex,
+        rootIndex: addressRootIndex,
+      },
+      outputTreeIndex,
+      remainingAccounts,
+      postCount,
+    });
+  } catch (err: unknown) {
+    console.error("Compressed post API error:", err);
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { error: `Failed to prepare compressed post: ${message}` },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## ZK Compressed Posts

Wires up the existing `create_compressed_post` program instruction in the frontend.

### How it works
1. **API route** (`/api/compressed-post`) runs server-side to fetch validity proof from Light Protocol indexer (SDK needs Node.js)
2. **Frontend** builds the transaction with proof data + remaining accounts, user signs with wallet
3. **Falls back** to regular PDA post if compression fails (e.g. RPC doesn't support compression)

### UI
- Toggle button: ⚡ Compressed (purple) / Regular (gray)
- Compression ON by default
- Purple success badge for compressed posts with Light Protocol attribution

### Cost impact
- Regular post: ~0.0017 SOL ($0.16) rent
- Compressed post: ~0.000005 SOL ($0.0005) tx fee only
- **312x cheaper**

### Requirements
- RPC must support ZK compression (Helius devnet/mainnet)
- Set `HELIUS_API_KEY` env var or `NEXT_PUBLIC_RPC_URL` pointing to compression-enabled RPC