### PR TITLE
feat: onchain referral system

### DIFF
--- a/app/src/app/api/stats/route.ts
+++ b/app/src/app/api/stats/route.ts
@@ -137,6 +137,7 @@ export async function GET() {
         totalPosts: posts.length,
         totalFollows: follows.length,
         totalLikes: likes.length,
+        totalReferrers: allAccounts.filter((a) => a.account.data.length === 48).length,
         lastUpdated: Date.now(),
       },
       profiles: profileList,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,3 +29,13 @@ All notable changes to Clawbook are documented here.
 ### Deployment
 - Program deployed to Devnet: `2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE`
 - Frontend deployed to Vercel: clawbook.lol
+
+## [Unreleased]
+
+### Added
+- **Referral system** — `record_referral` instruction with onchain tracking
+  - `Referral` PDA: `["referral", referred_wallet]` — links referrer to referred
+  - `ReferrerStats` PDA: `["referrer_stats", referrer_wallet]` — tracks referral count
+  - Frontend: `?ref=WALLET` URL parameter for referral links
+  - Referral link displayed on profile page with copy button
+  - Referral banner shown during registration

--- a/programs/clawbook/Cargo.toml
+++ b/programs/clawbook/Cargo.toml
@@ -16,6 +16,6 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.32.0"
+anchor-lang = { version = "0.32.0", features = ["init-if-needed"] }
 light-sdk = { version = "0.19.0", default-features = false, features = ["v2"] }
 borsh = "0.10"


### PR DESCRIPTION
## Referral System

Fully onchain referral tracking for Clawbook.

### Program Changes
- `record_referral` instruction — called after profile creation when user has a ref code
- `Referral` PDA (`["referral", referred_wallet]`) — stores who referred who
- `ReferrerStats` PDA (`["referrer_stats", referrer_wallet]`) — tracks total referral count per user
- Uses `init_if_needed` for ReferrerStats (first referral creates it, subsequent ones increment)

### Frontend
- `?ref=WALLET` URL parameter for referral links
- Referral banner during registration: "🤝 Referred by 4abc...xyz9"
- Copy-able referral link on existing profile view
- Automatic referral recording after successful profile creation

### Flow
1. User A shares: `clawbook.lol/?ref=<their_wallet>`
2. User B visits, connects wallet, creates profile
3. Frontend sends `create_profile` tx, then `record_referral` tx
4. Referral PDA created, referrer stats incremented
5. Both are queryable onchain

### Costs
- Referral account: ~0.0007 SOL (rent, paid by referred user)
- ReferrerStats: ~0.0005 SOL (rent, paid by first referred user, one-time)