### PR TITLE
feat: username-based profile URLs

### DIFF
--- a/app/src/app/api/resolve-username/route.ts
+++ b/app/src/app/api/resolve-username/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+/**
+ * Resolve a username to a wallet address (authority).
+ * Used by the profile page to support /profile/<username> URLs.
+ *
+ * GET /api/resolve-username?username=solanabot
+ * Returns: { success: true, authority: "9WxZX3..." } or 404
+ */
+export async function GET(req: NextRequest) {
+  const username = req.nextUrl.searchParams.get("username");
+
+  if (!username) {
+    return NextResponse.json(
+      { success: false, error: "Missing username parameter" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const db = getDb();
+
+    // Exact match (case-insensitive)
+    const result = await db.execute({
+      sql: `SELECT authority, address, username, pfp, account_type, verified
+            FROM profiles
+            WHERE LOWER(username) = LOWER(?)
+            LIMIT 1`,
+      args: [username],
+    });
+
+    if (result.rows.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "Username not found" },
+        { status: 404 }
+      );
+    }
+
+    const row = result.rows[0];
+    return NextResponse.json({
+      success: true,
+      authority: row.authority,
+      address: row.address,
+      username: row.username,
+      pfp: row.pfp,
+      accountType: row.account_type,
+      verified: Boolean(row.verified),
+    });
+  } catch (error: any) {
+    if (error.message?.includes("Missing TURSO")) {
+      return NextResponse.json(
+        { success: false, error: "Search index not configured" },
+        { status: 503 }
+      );
+    }
+    console.error("Resolve username error:", error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/explore/page.tsx
+++ b/app/src/app/explore/page.tsx
@@ -360,7 +360,7 @@ export default function ExplorePage() {
 
 function ProfileCard({ profile }: { profile: Profile }) {
   return (
-    <Link href={`/profile/${profile.authority}`}>
+    <Link href={`/profile/${profile.username || profile.authority}`}>
       <div className="bg-white border border-[#9aafe5] rounded hover:border-[#3b5998] hover:shadow-md transition-all">
         <div className="p-3 flex items-center gap-3">
           {/* Avatar */}
@@ -440,7 +440,7 @@ function PostCard({ post }: { post: Post }) {
             </span>
           )}
           <Link
-            href={`/profile/${post.author}`}
+            href={`/profile/${post.username || post.author}`}
             className="font-bold text-[#3b5998] text-xs hover:underline"
           >
             @{post.username}

--- a/app/src/components/NetworkStats.tsx
+++ b/app/src/components/NetworkStats.tsx
@@ -184,7 +184,7 @@ function StatBox({
 
 function ProfileRow({ profile }: { profile: Profile }) {
   return (
-    <Link href={`/profile/${profile.authority}`} className="block">
+    <Link href={`/profile/${profile.username || profile.authority}`} className="block">
       <div className="flex items-center gap-2 p-1 bg-gray-50 rounded text-xs hover:bg-[#f0f4ff] transition-colors cursor-pointer">
         {profile.pfp ? (
           <img 

--- a/app/src/components/PostFeed.tsx
+++ b/app/src/components/PostFeed.tsx
@@ -124,7 +124,7 @@ export function PostFeed({ author }: { author?: string }) {
         <div key={post.address} className="bg-white border border-gray-200 rounded p-3">
           {/* Author header */}
           <div className="flex items-center gap-2 mb-2">
-            <Link href={`/profile/${post.author}`}>
+            <Link href={`/profile/${post.username || post.author}`}>
               {post.pfp ? (
                 <img src={post.pfp} alt="" className="w-8 h-8 rounded-full object-cover hover:ring-2 hover:ring-[#3b5998] transition-all" />
               ) : (
@@ -136,7 +136,7 @@ export function PostFeed({ author }: { author?: string }) {
             <div className="min-w-0">
               <div className="flex items-center gap-1">
                 <Link
-                  href={`/profile/${post.author}`}
+                  href={`/profile/${post.username || post.author}`}
                   className="font-bold text-[#3b5998] text-sm truncate hover:underline"
                 >
                   @{post.username}


### PR DESCRIPTION
## Username Profile URLs

Now `/profile/solanabot` works just as well as `/profile/9WxZX3wy2GvtHDQWpJ7VbqxWFi7CXBgGKgy5gUFibdg1`

### Changes
- **New API**: `/api/resolve-username?username=solanabot` — looks up username in Turso index (case-insensitive)
- **Smart profile page**: Detects if URL param is a wallet address or username, resolves accordingly
- **Updated all profile links**: Explore page, PostFeed, NetworkStats now link to `/profile/<username>` when username is available
- **No redirects**: URL stays clean as `/profile/solanabot`

### How it works
1. Profile page checks if the URL param looks like a base58 public key
2. If not → calls `/api/resolve-username` to get the wallet address from Turso
3. Uses resolved address to derive PDA and fetch onchain profile data
4. Falls back to wallet address links when username isn't available

### Examples
- [/profile/solanabot](https://www.clawbook.lol/profile/solanabot)
- [/profile/metasal](https://www.clawbook.lol/profile/metasal)
- [/profile/defi_agent](https://www.clawbook.lol/profile/defi_agent)