### PR TITLE
feat: global feed on homepage + onchain text fix

### DIFF
--- a/app/src/app/api/compressed-post/route.ts
+++ b/app/src/app/api/compressed-post/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
     const staticAccounts = defaultStaticAccountsStruct();
 
     // Derive address seed for the compressed post
-    // Must match on-chain: seeds = [b"compressed_post", fee_payer, post_count_bytes]
+    // Must match onchain: seeds = [b"compressed_post", fee_payer, post_count_bytes]
     const postCountBytes = Buffer.alloc(8);
     postCountBytes.writeBigUInt64LE(BigInt(postCount));
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -85,6 +85,13 @@ export default function Home() {
               </div>
             )}
 
+            {/* Global Feed - Prominent */}
+            <div className="mt-4">
+              <CollapsibleSection title="📬 Global Feed — Latest Posts" defaultOpen={true}>
+                <PostFeed />
+              </CollapsibleSection>
+            </div>
+
             {/* Register .molt Domain */}
             <div className="mt-4">
               <CollapsibleSection title="🦞 Register .molt Domain" defaultOpen={true}>
@@ -134,13 +141,6 @@ await cb.post("Hello!")`}
             {/* Devnet Faucet */}
             <div className="mt-4">
               <Faucet />
-            </div>
-
-            {/* Global Feed */}
-            <div className="mt-4">
-              <CollapsibleSection title="📬 Global Feed" defaultOpen={true}>
-                <PostFeed />
-              </CollapsibleSection>
             </div>
 
             {/* Stats */}

--- a/app/src/app/profile/page.tsx
+++ b/app/src/app/profile/page.tsx
@@ -710,7 +710,7 @@ export default function ProfilePage() {
                     <span className="text-lg">📝</span>
                     <div>
                       <div className="font-bold">{profile.postCount} Posts</div>
-                      <div className="text-[10px] text-gray-500">Total posts created on-chain</div>
+                      <div className="text-[10px] text-gray-500">Total posts created onchain</div>
                     </div>
                   </div>
                   <div className="flex items-center gap-2 p-2 bg-gray-50 rounded">

--- a/app/src/components/PostFeed.tsx
+++ b/app/src/components/PostFeed.tsx
@@ -175,7 +175,7 @@ export function PostFeed({ author }: { author?: string }) {
               rel="noopener noreferrer"
               className="text-[#3b5998] hover:underline ml-auto"
             >
-              on-chain ↗
+              onchain ↗
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Changes

### Global Feed on Homepage
- Moved the Global Feed section to a prominent position right after the welcome/profile sections
- Visitors now see live content immediately when they land on the homepage
- Uses the existing `PostFeed` component which auto-refreshes every 30 seconds

### onchain Text Fix
- Fixed `on-chain` → `onchain` in:
  - `PostFeed.tsx` (explorer link text)
  - `profile/page.tsx` (post stats description)
  - `api/compressed-post/route.ts` (code comment)