### PR TITLE
Add registered .molt domains grid to /domains page

### DIFF
--- a/app/src/app/api/domain/list/route.ts
+++ b/app/src/app/api/domain/list/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { Connection } from "@solana/web3.js";
+import { TldParser } from "@onsol/tldparser";
+
+const MAINNET_RPC = "https://viviyan-bkj12u-fast-mainnet.helius-rpc.com";
+
+export async function GET() {
+  try {
+    const connection = new Connection(MAINNET_RPC, "confirmed");
+    const parser = new TldParser(connection);
+
+    // Get all domains under .molt TLD
+    const allDomains = await parser.getAllDomainsFromTld(".molt");
+
+    const domains = (allDomains || []).map((d: any) => ({
+      domain: typeof d === "string" ? d : d.domain || d.key?.toString() || String(d),
+    }));
+
+    return NextResponse.json({ domains, total: domains.length });
+  } catch (error: any) {
+    console.error("Domain list error:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Changes
- New `/api/domain/list` endpoint fetches all registered .molt domains via TldParser
- Updated `/domains` page with a grid showing up to 12 registered domains
- Click any domain to instantly lookup its owner details
- Shows total registered domain count at the bottom

## What it looks like
- 🦞 Grid of registered .molt domains in orange cards
- Click a domain → auto-fills search and looks up owner
- Total count displayed below the grid

Powered by @onsol/tldparser for on-chain domain resolution.