### PR TITLE
Fix /id page: resolve all 3 .molt domains correctly

### DIFF
--- a/app/src/app/id/page.tsx
+++ b/app/src/app/id/page.tsx
@@ -9,6 +9,7 @@ interface RegisteredDomain {
   domain: string;
   owner?: string;
   expiresAt?: string;
+  createdAt?: string;
 }
 
 export default function DomainsPage() {
@@ -219,6 +220,11 @@ export default function DomainsPage() {
                             >
                               {d.owner.slice(0, 6)}...{d.owner.slice(-4)}
                             </a>
+                            {d.createdAt && (
+                              <span className="ml-2 text-gray-400">
+                                · registered {new Date(d.createdAt).toLocaleDateString()}
+                              </span>
+                            )}
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Problem
The `/api/domain/list` endpoint used hardcoded domain names (`solana`, `metasal`, `clawbook`) and `getDomainKey` matching — which only found 1 of 3 domains. The actual domains are **ceo.molt**, **miester.molt**, and **solana.molt**.

## Fix
Replaced with dynamic reverse lookup using `reverseLookupNameAccount(key, parentRecord.owner)`. The key insight: the reverse lookup requires the **TLD parent account's owner** (`H7Hure...`), not the parent account key itself.

## Changes
- `/api/domain/list` — rewritten to dynamically resolve all domains via on-chain reverse lookup
- `/id` page — shows registration date for each domain

## Result
All 3 registered .molt domains now load correctly:
1. **ceo.molt** — owner: `anoNar...EjsW` (Feb 3, 2026)
2. **miester.molt** — owner: `2EGGxj...2D67` (Feb 3, 2026)
3. **solana.molt** — owner: `7gwkyD...j7BU` (Feb 7, 2026)

🦞