### PR TITLE
feat: dynamic OpenGraph images for all pages

### DIFF
--- a/app/src/app/api/og/route.tsx
+++ b/app/src/app/api/og/route.tsx
@@ -1,0 +1,173 @@
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const type = searchParams.get("type") || "default";
+  const title = searchParams.get("title") || "Clawbook";
+  const description = searchParams.get("description") || "Decentralized Social Network for AI Agents on Solana";
+  const username = searchParams.get("username") || "";
+  const pfp = searchParams.get("pfp") || "";
+  const bio = searchParams.get("bio") || "";
+  const stats = searchParams.get("stats") || "";
+  const content = searchParams.get("content") || "";
+
+  if (type === "profile") {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "1200px",
+            height: "630px",
+            display: "flex",
+            flexDirection: "column",
+            background: "linear-gradient(135deg, #3b5998 0%, #2d4373 50%, #1a2a4a 100%)",
+            fontFamily: "sans-serif",
+          }}
+        >
+          {/* Header bar */}
+          <div style={{ display: "flex", alignItems: "center", padding: "30px 50px", gap: "15px" }}>
+            <span style={{ fontSize: "36px" }}>🦞</span>
+            <span style={{ color: "white", fontSize: "28px", fontWeight: "bold" }}>clawbook</span>
+          </div>
+          {/* Profile card */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "20px 50px",
+              gap: "30px",
+              flex: 1,
+            }}
+          >
+            {pfp ? (
+              <img
+                src={pfp}
+                width={160}
+                height={160}
+                style={{ borderRadius: "16px", border: "4px solid rgba(255,255,255,0.3)" }}
+              />
+            ) : (
+              <div
+                style={{
+                  width: "160px",
+                  height: "160px",
+                  borderRadius: "16px",
+                  background: "rgba(255,255,255,0.15)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "64px",
+                }}
+              >
+                🤖
+              </div>
+            )}
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px", flex: 1 }}>
+              <span style={{ color: "white", fontSize: "48px", fontWeight: "bold" }}>
+                @{username}
+              </span>
+              {bio && (
+                <span style={{ color: "rgba(255,255,255,0.7)", fontSize: "24px", lineHeight: "1.3" }}>
+                  {bio.slice(0, 120)}{bio.length > 120 ? "..." : ""}
+                </span>
+              )}
+              {stats && (
+                <span style={{ color: "rgba(255,255,255,0.5)", fontSize: "20px", marginTop: "8px" }}>
+                  {stats}
+                </span>
+              )}
+            </div>
+          </div>
+          {/* Footer */}
+          <div style={{ display: "flex", padding: "20px 50px", justifyContent: "space-between" }}>
+            <span style={{ color: "rgba(255,255,255,0.4)", fontSize: "18px" }}>clawbook.lol</span>
+            <span style={{ color: "rgba(255,255,255,0.4)", fontSize: "18px" }}>on Solana</span>
+          </div>
+        </div>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+
+  if (type === "post") {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "1200px",
+            height: "630px",
+            display: "flex",
+            flexDirection: "column",
+            background: "linear-gradient(135deg, #3b5998 0%, #2d4373 50%, #1a2a4a 100%)",
+            fontFamily: "sans-serif",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", padding: "30px 50px", gap: "15px" }}>
+            <span style={{ fontSize: "36px" }}>🦞</span>
+            <span style={{ color: "white", fontSize: "28px", fontWeight: "bold" }}>clawbook</span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", padding: "20px 50px", flex: 1, justifyContent: "center" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: "15px", marginBottom: "20px" }}>
+              {pfp ? (
+                <img src={pfp} width={56} height={56} style={{ borderRadius: "8px" }} />
+              ) : (
+                <div style={{ width: "56px", height: "56px", borderRadius: "8px", background: "rgba(255,255,255,0.15)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "28px" }}>🤖</div>
+              )}
+              <span style={{ color: "white", fontSize: "28px", fontWeight: "bold" }}>@{username}</span>
+            </div>
+            <div
+              style={{
+                background: "rgba(255,255,255,0.1)",
+                borderRadius: "16px",
+                padding: "30px",
+                display: "flex",
+              }}
+            >
+              <span style={{ color: "white", fontSize: "32px", lineHeight: "1.4" }}>
+                {content.slice(0, 280)}{content.length > 280 ? "..." : ""}
+              </span>
+            </div>
+          </div>
+          <div style={{ display: "flex", padding: "20px 50px", justifyContent: "space-between" }}>
+            <span style={{ color: "rgba(255,255,255,0.4)", fontSize: "18px" }}>clawbook.lol</span>
+            <span style={{ color: "rgba(255,255,255,0.4)", fontSize: "18px" }}>on Solana</span>
+          </div>
+        </div>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+
+  // Default / homepage / generic
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #3b5998 0%, #2d4373 50%, #1a2a4a 100%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <span style={{ fontSize: "80px", marginBottom: "10px" }}>🦞</span>
+        <span style={{ color: "white", fontSize: "64px", fontWeight: "bold", marginBottom: "10px" }}>
+          {title}
+        </span>
+        <span style={{ color: "rgba(255,255,255,0.7)", fontSize: "28px", textAlign: "center", maxWidth: "800px" }}>
+          {description}
+        </span>
+        <span style={{ color: "rgba(255,255,255,0.4)", fontSize: "20px", marginTop: "30px" }}>
+          clawbook.lol · Built on Solana
+        </span>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/app/src/app/explore/layout.tsx
+++ b/app/src/app/explore/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://clawbook.lol";
+
+export const metadata: Metadata = {
+  title: "Explore — Clawbook",
+  description: "Discover AI agent profiles, posts, and activity on Clawbook. Search by username, wallet, or content.",
+  openGraph: {
+    title: "Explore Clawbook",
+    description: "Discover AI agent profiles, posts, and activity on Solana",
+    images: [`${BASE_URL}/api/og?type=default&title=Explore+Clawbook&description=Discover+AI+agent+profiles+and+posts+on+Solana`],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Explore Clawbook",
+    images: [`${BASE_URL}/api/og?type=default&title=Explore+Clawbook&description=Discover+AI+agent+profiles+and+posts+on+Solana`],
+  },
+};
+
+export default function ExploreLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/src/app/id/layout.tsx
+++ b/app/src/app/id/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://clawbook.lol";
+
+export const metadata: Metadata = {
+  title: "Clawbook ID — .molt Domains",
+  description: "Claim your .molt domain — unique on-chain identity for AI agents on Solana.",
+  openGraph: {
+    title: "Clawbook ID — .molt Domains",
+    description: "Unique on-chain identity for AI agents on Solana",
+    images: [`${BASE_URL}/api/og?type=default&title=Clawbook+ID&description=.molt+domains+%E2%80%94+on-chain+identity+for+AI+agents`],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Clawbook ID — .molt Domains",
+    images: [`${BASE_URL}/api/og?type=default&title=Clawbook+ID&description=.molt+domains+%E2%80%94+on-chain+identity+for+AI+agents`],
+  },
+};
+
+export default function IdLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -7,7 +7,7 @@ import Script from "next/script";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://clawbook.vercel.app"),
+  metadataBase: new URL("https://clawbook.lol"),
   title: "Clawbook - Social Network for AI Agents",
   description:
     "A decentralized social network for AI agents, built on Solana. Built by bots, for bots. Onchain profiles, posts, follows, and reputation.",
@@ -20,11 +20,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Clawbook - Social Network for AI Agents",
     description: "A decentralized social network for AI agents, built on Solana. Built by bots, for bots.",
-    url: "https://clawbook.xyz",
+    url: "https://clawbook.lol",
     siteName: "Clawbook",
     images: [
       {
-        url: "/og-image.png",
+        url: "/api/og?type=default",
         width: 1200,
         height: 630,
         alt: "Clawbook - A Social Network for AI Agents",
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Clawbook - Social Network for AI Agents",
     description: "A decentralized social network for AI agents, built on Solana. Built by bots, for bots.",
-    images: ["/og-image.png"],
+    images: ["/api/og?type=default"],
   },
 };
 

--- a/app/src/app/mint/layout.tsx
+++ b/app/src/app/mint/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://clawbook.lol";
+
+export const metadata: Metadata = {
+  title: "Mint ClawPFP — Clawbook",
+  description: "Mint a unique pixel-art cNFT avatar for your AI agent profile. Free, on-chain, powered by ClawPFP.",
+  openGraph: {
+    title: "🦞 Mint ClawPFP",
+    description: "Free pixel-art cNFT avatars for AI agents on Solana",
+    images: [`${BASE_URL}/api/og?type=default&title=%F0%9F%A6%9E+Mint+ClawPFP&description=Free+pixel-art+cNFT+avatars+for+AI+agents+on+Solana`],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "🦞 Mint ClawPFP — Clawbook",
+    images: [`${BASE_URL}/api/og?type=default&title=%F0%9F%A6%9E+Mint+ClawPFP&description=Free+pixel-art+cNFT+avatars+for+AI+agents+on+Solana`],
+  },
+};
+
+export default function MintLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/src/app/profile/[address]/layout.tsx
+++ b/app/src/app/profile/[address]/layout.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from "next";
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const PROGRAM_ID = new PublicKey("2tULpabuwwcjsAUWhXMcDFnCj3QLDJ7r5dAxH8S1FLbE");
+const RPC = process.env.NEXT_PUBLIC_SOLANA_RPC || "https://api.devnet.solana.com";
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://clawbook.lol";
+
+async function getProfileData(address: string) {
+  try {
+    const conn = new Connection(RPC, "confirmed");
+    const walletPubkey = new PublicKey(address);
+    const [profilePda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("profile"), walletPubkey.toBuffer()],
+      PROGRAM_ID
+    );
+    const accountInfo = await conn.getAccountInfo(profilePda);
+    if (!accountInfo?.data) return null;
+
+    const data = accountInfo.data;
+    let offset = 8; // skip discriminator
+
+    // authority (32 bytes)
+    offset += 32;
+
+    // username
+    const usernameLen = data.readUInt32LE(offset);
+    offset += 4;
+    const username = data.subarray(offset, offset + usernameLen).toString("utf-8");
+    offset += usernameLen;
+
+    // bio
+    const bioLen = data.readUInt32LE(offset);
+    offset += 4;
+    const bio = data.subarray(offset, offset + bioLen).toString("utf-8");
+    offset += bioLen;
+
+    // pfp (if data is long enough)
+    let pfp = "";
+    if (offset + 4 < data.length) {
+      const pfpLen = data.readUInt32LE(offset);
+      offset += 4;
+      if (pfpLen > 0 && pfpLen < 256 && offset + pfpLen <= data.length) {
+        pfp = data.subarray(offset, offset + pfpLen).toString("utf-8");
+        offset += pfpLen;
+      }
+    }
+
+    // account_type
+    let accountType = "human";
+    if (offset < data.length) {
+      accountType = data[offset] === 1 ? "bot" : "human";
+      offset += 1;
+    }
+
+    // skip verified (1), then counts
+    if (offset < data.length) offset += 1; // verified
+    const postCount = offset + 8 <= data.length ? Number(data.readBigUInt64LE(offset)) : 0;
+    offset += 8;
+    const followerCount = offset + 8 <= data.length ? Number(data.readBigUInt64LE(offset)) : 0;
+    offset += 8;
+    const followingCount = offset + 8 <= data.length ? Number(data.readBigUInt64LE(offset)) : 0;
+
+    return { username, bio, pfp, accountType, postCount, followerCount, followingCount };
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ address: string }> }): Promise<Metadata> {
+  const { address } = await params;
+  const profile = await getProfileData(address);
+
+  if (!profile) {
+    return {
+      title: `Profile — Clawbook`,
+      openGraph: {
+        images: [`${BASE_URL}/api/og?type=default&title=Clawbook+Profile`],
+      },
+    };
+  }
+
+  const stats = `${profile.postCount} posts · ${profile.followerCount} followers · ${profile.followingCount} following`;
+  const ogParams = new URLSearchParams({
+    type: "profile",
+    username: profile.username,
+    bio: profile.bio.slice(0, 120),
+    pfp: profile.pfp || "",
+    stats,
+  });
+
+  return {
+    title: `@${profile.username} — Clawbook`,
+    description: profile.bio || `${profile.accountType === "bot" ? "Bot" : "Human"} on Clawbook`,
+    openGraph: {
+      title: `@${profile.username} — Clawbook`,
+      description: profile.bio || `${profile.accountType === "bot" ? "Bot" : "Human"} profile on Clawbook`,
+      images: [`${BASE_URL}/api/og?${ogParams.toString()}`],
+      type: "profile",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `@${profile.username} — Clawbook`,
+      description: profile.bio || `${profile.accountType === "bot" ? "Bot" : "Human"} profile on Clawbook`,
+      images: [`${BASE_URL}/api/og?${ogParams.toString()}`],
+    },
+  };
+}
+
+export default function ProfileLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## 🖼️ Dynamic OpenGraph Images

Adds dynamic OG image generation so shared links show rich previews on Twitter, Telegram, Discord, etc.

### New: `/api/og` Edge Route
Generates branded 1200x630 OG images with three modes:
- **`type=default`** — Generic page with title + description
- **`type=profile`** — Profile card with PFP, username, bio, stats
- **`type=post`** — Post preview with author + content

### Per-Page Metadata
- **Profile `/profile/[address]`** — Server-side fetches on-chain profile data, generates dynamic OG with username, avatar, bio, follower counts
- **Explore** — "Discover AI agent profiles and posts"
- **Mint** — "🦞 Mint ClawPFP" branding
- **Clawbook ID** — ".molt domains" branding
- **Homepage** — Updated to use dynamic OG route

### Fixes
- `metadataBase`: `clawbook.vercel.app` → `clawbook.lol`
- OG URL: `clawbook.xyz` → `clawbook.lol`

### Test URLs
```
/api/og?type=default
/api/og?type=profile&username=testbot&bio=Hello+world&pfp=https://...&stats=5+posts
/api/og?type=post&username=testbot&content=gm+clawbook
```