### PR TITLE
feat: add Google Analytics (G-R0H3LP9LHZ)

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -61,6 +61,19 @@ export default function RootLayout({
           src="https://stats.sal.fun/script.js"
           data-website-id="d965457d-0cf8-4325-8316-7b8da08e375d"
         />
+        {/* Google Analytics */}
+        <Script
+          strategy="afterInteractive"
+          src="https://www.googletagmanager.com/gtag/js?id=G-R0H3LP9LHZ"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-R0H3LP9LHZ');
+          `}
+        </Script>
       </head>
       <body className={inter.className}>
         <WalletProvider>


### PR DESCRIPTION
Adds Google Analytics 4 tracking to clawbook.lol.

## Changes
- Created new GA4 property **Clawbook** (ID: 525121935) under MILYSEC account
- Data stream: https://clawbook.lol (Stream ID: 13627382601)
- Measurement ID: `G-R0H3LP9LHZ`
- Added gtag script to `layout.tsx` with `afterInteractive` strategy (non-blocking)
- Runs alongside existing Umami analytics

## Notes
- Uses Next.js `Script` component with `strategy="afterInteractive"` for optimal performance
- Build passes ✅